### PR TITLE
DATAGO-67107 Added support for forwarding Solace message user properties to Kafka record headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ In this case the IP address is one of the nodes running the distributed mode wor
   {
     "class": "com.solace.connector.kafka.connect.source.SolaceSourceConnector",
     "type": "source",
-    "version": "3.0.1"
+    "version": "3.1.0"
   },
 ```
 
@@ -373,6 +373,14 @@ For reference, this project includes two examples which you can use as starting 
 
 * [SolSampleSimpleMessageProcessor](/src/main/java/com/solace/connector/kafka/connect/source/msgprocessors/SolSampleSimpleMessageProcessor.java)
 * [SolaceSampleKeyedMessageProcessor](/src/main/java/com/solace/connector/kafka/connect/source/msgprocessors/SolaceSampleKeyedMessageProcessor.java)
+
+Above two processors by default won't map/forward the Solace message user properties and Solace standard properties. If you want to map/forward them as Kafka record headers set below two properties to `true` in connector configuration. Refer sample [here](/etc/solace_source_properties.json) and [Parameters section](#parameters) section for details.
+
+```
+sol.message_processor.map_user_properties=true
+sol.message_processor.map_solace_standard_properties=true
+```
+
 
 Once you've built the jar file for your custom message processor project, place it into the same directory as this connector, and update the connector's `sol.message_processor_class` config to point to the class of your new message processor.
 

--- a/etc/solace_source.properties
+++ b/etc/solace_source.properties
@@ -35,6 +35,13 @@ sol.message_processor_class=com.solace.connector.kafka.connect.source.msgprocess
 # If enabled, messages that throw message processor errors will be discarded.
 #sol.message_processor.error.ignore=false
 
+# If enabled, maps/forwards the user properties Map from Solace message to Kafka record headers
+#sol.message_processor.map_user_properties=false
+
+# If enabled, maps/forwards the Solace message standard properties (e.g. correlationId, applicationMessageId, redelivered, dmqEligible, COS etc) to Kafka record headers
+# The Solace standard properties names will be prefixed with "solace_" (e.g. correlationId as solace_correlationId) to Kafka record headers
+#sol.message_processor.map_solace_standard_properties=false
+
 # When using SolaceSampleKeyedMessageProcessor, defines which part of a
 # PubSub+ message shall be converted to a Kafka record key
 # Allowable values include: NONE, DESTINATION, CORRELATION_ID, CORRELATION_ID_AS_BYTES

--- a/etc/solace_source_properties.json
+++ b/etc/solace_source_properties.json
@@ -11,6 +11,8 @@
     "sol.vpn_name": "default",
     "sol.topics": "sourcetest",
     "sol.message_processor_class": "com.solace.connector.kafka.connect.source.msgprocessors.SolSampleSimpleMessageProcessor",
+    "sol.message_processor.map_user_properties": "false",
+    "sol.message_processor.map_solace_standard_properties": "false",
     "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter"	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.solace.connector.kafka.connect
-version=3.0.1
+version=3.1.0

--- a/src/main/java/com/solace/connector/kafka/connect/source/SolMessageProcessorIF.java
+++ b/src/main/java/com/solace/connector/kafka/connect/source/SolMessageProcessorIF.java
@@ -19,12 +19,165 @@
 
 package com.solace.connector.kafka.connect.source;
 
+import com.solacesystems.common.util.ByteArray;
 import com.solacesystems.jcsmp.BytesXMLMessage;
-
+import com.solacesystems.jcsmp.Destination;
+import com.solacesystems.jcsmp.SDTException;
+import com.solacesystems.jcsmp.SDTMap;
+import com.solacesystems.jcsmp.Topic;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface SolMessageProcessorIF {
+
+  Logger log = LoggerFactory.getLogger(SolMessageProcessorIF.class);
+
   SolMessageProcessorIF process(String skey, BytesXMLMessage message);
 
   SourceRecord[] getRecords(String kafkaTopic);
+
+  default ConnectHeaders userPropertiesToKafkaHeaders(BytesXMLMessage message) {
+    final ConnectHeaders headers = new ConnectHeaders();
+    final SDTMap msgUserProperties = message.getProperties();
+
+    if (msgUserProperties != null) {
+      for (String propKey : msgUserProperties.keySet()) {
+        try {
+          Object propValue = msgUserProperties.get(propKey);
+          if (propValue == null) {
+            headers.add(propKey, SchemaAndValue.NULL);
+          } else if (propValue instanceof String) {
+            headers.addString(propKey, (String) propValue);
+          } else if (propValue instanceof Boolean) {
+            headers.addBoolean(propKey, (Boolean) propValue);
+          } else if (propValue instanceof byte[]) {
+            headers.addBytes(propKey, (byte[]) propValue);
+          } else if (propValue instanceof ByteArray) {
+            headers.addBytes(propKey, ((ByteArray) propValue).asBytes());
+          } else if (propValue instanceof Byte) {
+            headers.addByte(propKey, (byte) propValue);
+          } else if (propValue instanceof Integer) {
+            headers.addInt(propKey, (Integer) propValue);
+          } else if (propValue instanceof Short) {
+            headers.addShort(propKey, (Short) propValue);
+          } else if (propValue instanceof Long) {
+            headers.addLong(propKey, (Long) propValue);
+          } else if (propValue instanceof Double) {
+            headers.addDouble(propKey, (Double) propValue);
+          } else if (propValue instanceof Float) {
+            headers.addFloat(propKey, (Float) propValue);
+          } else if (propValue instanceof BigDecimal) {
+            headers.addDecimal(propKey, (BigDecimal) propValue);
+          } else if (propValue instanceof BigInteger) {
+            headers.addDecimal(propKey, new BigDecimal((BigInteger) propValue));
+          } else if (propValue instanceof Date) {
+            headers.addDate(propKey, (Date) propValue);
+          } else if (propValue instanceof Character) {
+            headers.addString(propKey, ((Character) propValue).toString());
+          } else if (propValue instanceof Destination) {
+            if (log.isTraceEnabled()) {
+              log.trace(
+                  String.format("Extracting destination name from user property %s", propKey));
+            }
+            String destinationName = ((Destination) propValue).getName();
+            headers.addString(propKey, destinationName);
+          } else {
+            if (log.isInfoEnabled()) {
+              log.info(String.format("Ignoring user property with key [%s] and type [%s]", propKey,
+                  propValue.getClass().getName()));
+            }
+          }
+        } catch (SDTException e) {
+          log.error(String.format("Ignoring user property with key [%s].", propKey), e);
+        }
+      }
+    }
+
+    return headers;
+  }
+
+  default ConnectHeaders solacePropertiesToKafkaHeaders(BytesXMLMessage msg) {
+    final ConnectHeaders headers = new ConnectHeaders();
+    if (msg.getApplicationMessageId() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_APPLICATION_MESSAGE_ID,
+          msg.getApplicationMessageId());
+    }
+
+    if (msg.getApplicationMessageType() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_APPLICATION_MESSAGE_TYPE,
+          msg.getApplicationMessageType());
+    }
+
+    if (msg.getCorrelationId() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_CORRELATION_ID, msg.getCorrelationId());
+    }
+
+    if (msg.getCos() != null) {
+      headers.addInt(SolaceSourceConstants.SOL_SH_COS, msg.getCos().value());
+    }
+
+    if (msg.getDeliveryMode() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_DELIVERY_MODE, msg.getDeliveryMode().name());
+    }
+
+    if (msg.getDestination() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_DESTINATION, msg.getDestination().getName());
+    }
+
+    if (msg.getReplyTo() != null) {
+      Destination replyToDestination = msg.getReplyTo();
+      headers.addString(SolaceSourceConstants.SOL_SH_REPLY_TO_DESTINATION,
+          replyToDestination.getName());
+      String destinationType = replyToDestination instanceof Topic ? "topic" : "queue";
+      headers.addString(SolaceSourceConstants.SOL_SH_REPLY_TO_DESTINATION_TYPE,
+          destinationType);
+    }
+
+    if (msg.getSenderId() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_SENDER_ID, msg.getSenderId());
+    }
+
+    if (msg.getSenderTimestamp() != null) {
+      headers.addLong(SolaceSourceConstants.SOL_SH_SENDER_TIMESTAMP, msg.getSenderTimestamp());
+    }
+
+    if (msg.getTimeToLive() > 0) {
+      headers.addLong(SolaceSourceConstants.SOL_SH_TIME_TO_LIVE, msg.getTimeToLive());
+    }
+
+    if (msg.getExpiration() > 0) {
+      headers.addLong(SolaceSourceConstants.SOL_SH_EXPIRATION, msg.getExpiration());
+    }
+
+    if (msg.getHTTPContentEncoding() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_HTTP_CONTENT_ENCODING,
+          msg.getHTTPContentEncoding());
+    }
+
+    if (msg.getHTTPContentType() != null) {
+      headers.addString(SolaceSourceConstants.SOL_SH_HTTP_CONTENT_TYPE,
+          msg.getHTTPContentType());
+    }
+
+    if (msg.getSequenceNumber() != null) {
+      headers.addLong(SolaceSourceConstants.SOL_SH_SEQUENCE_NUMBER, msg.getSequenceNumber());
+    }
+
+    headers.addInt(SolaceSourceConstants.SOL_SH_PRIORITY, msg.getPriority());
+    headers.addLong(SolaceSourceConstants.SOL_SH_RECEIVE_TIMESTAMP, msg.getReceiveTimestamp());
+
+    headers.addBoolean(SolaceSourceConstants.SOL_SH_REDELIVERED, msg.getRedelivered());
+    headers.addBoolean(SolaceSourceConstants.SOL_SH_DISCARD_INDICATION, msg.getDiscardIndication());
+    headers.addBoolean(SolaceSourceConstants.SOL_SH_IS_DMQ_ELIGIBLE, msg.isDMQEligible());
+    headers.addBoolean(SolaceSourceConstants.SOL_SH_IS_ELIDING_ELIGIBLE, msg.isElidingEligible());
+    headers.addBoolean(SolaceSourceConstants.SOL_SH_IS_REPLY_MESSAGE, msg.isReplyMessage());
+
+    return headers;
+  }
 }

--- a/src/main/java/com/solace/connector/kafka/connect/source/SolaceSourceConnectorConfig.java
+++ b/src/main/java/com/solace/connector/kafka/connect/source/SolaceSourceConnectorConfig.java
@@ -36,7 +36,7 @@ public class SolaceSourceConnectorConfig extends AbstractConfig {
    * Constructor to create Solace Configuration details for Source Connector.
    * @param properties the configuration properties
    */
-  public SolaceSourceConnectorConfig(Map<String, String> properties) {
+  public SolaceSourceConnectorConfig(Map<String, String>  properties) {
     super(config, properties);
 
     log.info("==================Initialize Connector properties");
@@ -254,7 +254,11 @@ public class SolaceSourceConnectorConfig extends AbstractConfig {
         .define(SolaceSourceConstants.SOL_KERBEROS_LOGIN_CONFIG, Type.STRING, "", Importance.LOW,
             "Location of the Kerberos Login Configuration File")
         .define(SolaceSourceConstants.SOL_KAFKA_MESSAGE_KEY, Type.STRING, "NONE", Importance.MEDIUM,
-            "This propert determines if a Kafka key record is created and the key to be used");
+            "This property determines if a Kafka key record is created and the key to be used")
+        .define(SolaceSourceConstants.SOL_MESSAGE_PROCESSOR_MAP_USER_PROPERTIES, Type.BOOLEAN, false, Importance.MEDIUM,
+            "This property determines if Solace message user properties will be mapped to Kafka record headers")
+        .define(SolaceSourceConstants.SOL_MESSAGE_PROCESSOR_MAP_SOLACE_STANDARD_PROPERTIES, Type.BOOLEAN, false, Importance.MEDIUM,
+            "This property determines if Solace message standard properties will be mapped to Kafka record headers");
 
 
   }

--- a/src/main/java/com/solace/connector/kafka/connect/source/SolaceSourceConstants.java
+++ b/src/main/java/com/solace/connector/kafka/connect/source/SolaceSourceConstants.java
@@ -138,5 +138,33 @@ public class SolaceSourceConstants {
   public static final String SOL_KERBEROS_LOGIN_CONFIG = "sol.kerberos.login.conf";
   public static final String SOL_KERBEROS_KRB5_CONFIG = "sol.kerberos.krb5.conf";
 
+  // Medium Importance Solace Message processor
+  public static final String SOL_MESSAGE_PROCESSOR_MAP_USER_PROPERTIES = "sol.message_processor.map_user_properties";
+  public static final String SOL_MESSAGE_PROCESSOR_MAP_SOLACE_STANDARD_PROPERTIES = "sol.message_processor.map_solace_standard_properties";
 
+
+  //All SOL_SH prefixed constants are Solace Message Standard Headers.
+  public static final String SOL_SH_APPLICATION_MESSAGE_ID = "solace_applicationMessageID";
+  public static final String SOL_SH_APPLICATION_MESSAGE_TYPE = "solace_applicationMessageType";
+  public static final String SOL_SH_CORRELATION_ID = "solace_correlationID";
+  public static final String SOL_SH_COS = "solace_cos";
+  public static final String SOL_SH_DELIVERY_MODE = "solace_deliveryMode";
+  public static final String SOL_SH_DESTINATION = "solace_destination";
+  public static final String SOL_SH_DISCARD_INDICATION = "solace_discardIndication";
+  public static final String SOL_SH_EXPIRATION = "solace_expiration";
+  public static final String SOL_SH_PRIORITY = "solace_priority";
+  public static final String SOL_SH_RECEIVE_TIMESTAMP = "solace_receiveTimestamp";
+  public static final String SOL_SH_REDELIVERED = "solace_redelivered";
+  public static final String SOL_SH_REPLY_TO = "solace_replyTo";
+  public static final String SOL_SH_REPLY_TO_DESTINATION_TYPE = "solace_replyToDestinationType";
+  public static final String SOL_SH_REPLY_TO_DESTINATION = "solace_replyToDestination";
+  public static final String SOL_SH_SENDER_ID = "solace_senderID";
+  public static final String SOL_SH_SENDER_TIMESTAMP = "solace_senderTimestamp";
+  public static final String SOL_SH_TIME_TO_LIVE = "solace_timeToLive";
+  public static final String SOL_SH_IS_DMQ_ELIGIBLE = "solace_DMQEligible";
+  public static final String SOL_SH_IS_ELIDING_ELIGIBLE = "solace_elidingEligible";
+  public static final String SOL_SH_IS_REPLY_MESSAGE = "solace_replyMessage";
+  public static final String SOL_SH_HTTP_CONTENT_ENCODING = "solace_httpContentEncoding";
+  public static final String SOL_SH_HTTP_CONTENT_TYPE = "solace_httpContentType";
+  public static final String SOL_SH_SEQUENCE_NUMBER = "solace_sequenceNumber";
 }

--- a/src/main/java/com/solace/connector/kafka/connect/source/msgprocessors/SolSampleSimpleMessageProcessor.java
+++ b/src/main/java/com/solace/connector/kafka/connect/source/msgprocessors/SolSampleSimpleMessageProcessor.java
@@ -19,60 +19,106 @@
 
 package com.solace.connector.kafka.connect.source.msgprocessors;
 
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_MESSAGE_PROCESSOR_MAP_SOLACE_STANDARD_PROPERTIES;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_MESSAGE_PROCESSOR_MAP_USER_PROPERTIES;
 import com.solace.connector.kafka.connect.source.SolMessageProcessorIF;
 import com.solacesystems.jcsmp.BytesXMLMessage;
-//import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.TextMessage;
-
 import java.nio.charset.Charset;
-
 import java.nio.charset.StandardCharsets;
-
+import java.util.LinkedList;
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SolSampleSimpleMessageProcessor implements SolMessageProcessorIF {
+public class SolSampleSimpleMessageProcessor implements SolMessageProcessorIF, Configurable {
 
   private static final Logger log = LoggerFactory.getLogger(SolSampleSimpleMessageProcessor.class);
   private Object smsg;
   private String skey;
   private Object sdestination;
   private byte[] messageOut;
+  private LinkedList<Header> headers = new LinkedList<>();
 
+  private Map<String, ?> configs;
+  private boolean mapUserProperties;
+  private boolean mapSolaceStandardProperties;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    this.configs = configs;
+    this.mapUserProperties = getBooleanConfigProperty(SOL_MESSAGE_PROCESSOR_MAP_USER_PROPERTIES);
+    this.mapSolaceStandardProperties = getBooleanConfigProperty(
+        SOL_MESSAGE_PROCESSOR_MAP_SOLACE_STANDARD_PROPERTIES);
+  }
 
   @Override
   public SolMessageProcessorIF process(String skey, BytesXMLMessage msg) {
     this.smsg = msg;
+    this.headers.clear();
     if (msg instanceof TextMessage) {
-      log.debug("Text Message received {}", ((TextMessage) msg).getText());
+      if (log.isDebugEnabled()) {
+        log.debug("Text Message received {}", ((TextMessage) msg).getText());
+      }
       String smsg = ((TextMessage) msg).getText();
       messageOut = smsg.getBytes(StandardCharsets.UTF_8);
     } else {
-      log.debug("Message payload: {}", new String(msg.getBytes(), Charset.defaultCharset()));
+      if (log.isDebugEnabled()) {
+        log.debug("Message payload: {}", new String(msg.getBytes(), Charset.defaultCharset()));
+      }
       if (msg.getBytes().length != 0) { // Binary XML pay load
         messageOut = msg.getBytes();
       } else { // Binary attachment pay load
         messageOut = msg.getAttachmentByteBuffer().array();
       }
     }
-    log.debug("Message Dump:{}", msg.dump());
 
     this.sdestination = msg.getDestination().getName();
-    log.debug("processing data for destination: {}; with message {}, with Kafka topic key of: {}",
-        (String) this.sdestination, msg, this.skey);
+    if (log.isDebugEnabled()) {
+      log.debug("Message Dump:{}", msg.dump());
+      log.debug("processing data for destination: {}; with message {}, with Kafka topic key of: {}",
+          (String) this.sdestination, msg, this.skey);
+    }
     this.skey = skey;
     this.smsg = messageOut;
+
+    if (mapUserProperties) {
+      ConnectHeaders userProps = userPropertiesToKafkaHeaders(msg);
+      userProps.iterator().forEachRemaining(headers::add);
+    }
+
+    if (mapSolaceStandardProperties) {
+      ConnectHeaders solaceProps = solacePropertiesToKafkaHeaders(msg);
+      solaceProps.iterator().forEachRemaining(headers::add);
+    }
+
     return this;
   }
 
   @Override
   public SourceRecord[] getRecords(String kafkaTopic) {
-   
-    return new SourceRecord[] {
-        new SourceRecord(null, null, kafkaTopic, null, null, 
-            null, Schema.BYTES_SCHEMA, smsg) };
+
+    return new SourceRecord[]{
+        new SourceRecord(null, null, kafkaTopic, null, null,
+            null, Schema.BYTES_SCHEMA, smsg, (Long) null, headers)};
   }
 
+  private boolean getBooleanConfigProperty(String name) {
+    if (this.configs != null && this.configs.containsKey(name)) {
+      final Object value = this.configs.get(name);
+      if (value instanceof String) {
+        return Boolean.parseBoolean((String) value);
+      } else if (value instanceof Boolean) {
+        return (boolean) value;
+      } else {
+        log.error("The value of property {} should be of type boolean or string.", name);
+      }
+    }
+    return false;
+  }
 }

--- a/src/main/java/com/solace/connector/kafka/connect/source/msgprocessors/SolaceSampleKeyedMessageProcessor.java
+++ b/src/main/java/com/solace/connector/kafka/connect/source/msgprocessors/SolaceSampleKeyedMessageProcessor.java
@@ -19,29 +19,34 @@
 
 package com.solace.connector.kafka.connect.source.msgprocessors;
 
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_MESSAGE_PROCESSOR_MAP_SOLACE_STANDARD_PROPERTIES;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_MESSAGE_PROCESSOR_MAP_USER_PROPERTIES;
 import com.solace.connector.kafka.connect.source.SolMessageProcessorIF;
 import com.solacesystems.jcsmp.BytesXMLMessage;
 import com.solacesystems.jcsmp.TextMessage;
-
 import java.nio.charset.Charset;
-
 import java.nio.charset.StandardCharsets;
-
+import java.util.LinkedList;
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SolaceSampleKeyedMessageProcessor implements SolMessageProcessorIF {
+public class SolaceSampleKeyedMessageProcessor implements SolMessageProcessorIF, Configurable {
 
-  private static final Logger log 
+  private static final Logger log
       = LoggerFactory.getLogger(SolaceSampleKeyedMessageProcessor.class);
   private Object smsg;
   private byte[] messageOut;
   private String skey;
   private BytesXMLMessage msg;
   private SchemaAndValue key;
+  private LinkedList<Header> headers = new LinkedList<>();
 
   public enum KeyHeader {
     NONE, DESTINATION, CORRELATION_ID, CORRELATION_ID_AS_BYTES
@@ -49,17 +54,34 @@ public class SolaceSampleKeyedMessageProcessor implements SolMessageProcessorIF 
 
   protected KeyHeader keyheader = KeyHeader.NONE;
 
+  private Map<String, ?> configs;
+  private boolean mapUserProperties;
+  private boolean mapSolaceStandardProperties;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    this.configs = configs;
+    this.mapUserProperties = getBooleanConfigProperty(SOL_MESSAGE_PROCESSOR_MAP_USER_PROPERTIES);
+    this.mapSolaceStandardProperties = getBooleanConfigProperty(
+        SOL_MESSAGE_PROCESSOR_MAP_SOLACE_STANDARD_PROPERTIES);
+  }
+
   @Override
   public SolMessageProcessorIF process(String skey, BytesXMLMessage msg) {
     this.msg = msg;
+    this.headers.clear();
     this.skey = skey.toUpperCase();
 
     if (msg instanceof TextMessage) {
-      log.debug("Text Mesasge received {}", ((TextMessage) msg).getText());
+      if (log.isDebugEnabled()) {
+        log.debug("Text Message received {}", ((TextMessage) msg).getText());
+      }
       String smsg = ((TextMessage) msg).getText();
       messageOut = smsg.getBytes(StandardCharsets.UTF_8);
     } else {
-      log.debug("Message payload: {}", new String(msg.getBytes(), Charset.defaultCharset()));
+      if (log.isDebugEnabled()) {
+        log.debug("Message payload: {}", new String(msg.getBytes(), Charset.defaultCharset()));
+      }
       if (msg.getBytes().length != 0) { // Binary XML pay load
         messageOut = msg.getBytes();
       } else { // Binary attachment pay load
@@ -67,9 +89,11 @@ public class SolaceSampleKeyedMessageProcessor implements SolMessageProcessorIF 
       }
 
     }
-    log.debug("Message Dump:{}", msg.dump());
 
-    log.debug("processing data for Kafka topic Key: {}; with message {}", skey, msg);
+    if (log.isDebugEnabled()) {
+      log.debug("Message Dump:{}", msg.dump());
+      log.debug("processing data for Kafka topic Key: {}; with message {}", skey, msg);
+    }
 
     this.smsg = messageOut;
 
@@ -85,16 +109,26 @@ public class SolaceSampleKeyedMessageProcessor implements SolMessageProcessorIF 
 
     this.key = this.getKey();
 
+    if (mapUserProperties) {
+      ConnectHeaders userProps = userPropertiesToKafkaHeaders(msg);
+      userProps.iterator().forEachRemaining(headers::add);
+    }
+
+    if (mapSolaceStandardProperties) {
+      ConnectHeaders solaceProps = solacePropertiesToKafkaHeaders(msg);
+      solaceProps.iterator().forEachRemaining(headers::add);
+    }
     return this;
   }
 
   @Override
   public SourceRecord[] getRecords(String kafkaTopic) {
-
-    log.debug("=======Key Schema: {}, Key Value: {}", this.key.schema(), this.key.value());
-    return new SourceRecord[] { new SourceRecord(null, null, kafkaTopic, 
+    if (log.isDebugEnabled()) {
+      log.debug("=======Key Schema: {}, Key Value: {}", this.key.schema(), this.key.value());
+    }
+    return new SourceRecord[]{new SourceRecord(null, null, kafkaTopic,
         null, this.key.schema(), this.key.value(),
-        Schema.BYTES_SCHEMA, smsg) };
+        Schema.BYTES_SCHEMA, smsg, null, headers)};
   }
 
   SchemaAndValue getKey() {
@@ -129,4 +163,17 @@ public class SolaceSampleKeyedMessageProcessor implements SolMessageProcessorIF 
     return new SchemaAndValue(keySchema, key);
   }
 
+  private boolean getBooleanConfigProperty(String name) {
+    if (this.configs != null && this.configs.containsKey(name)) {
+      final Object value = this.configs.get(name);
+      if (value instanceof String) {
+        return Boolean.parseBoolean((String) value);
+      } else if (value instanceof Boolean) {
+        return (boolean) value;
+      } else {
+        log.error("The value of property {} should be of type boolean or string.", name);
+      }
+    }
+    return false;
+  }
 }

--- a/src/test/java/com/solace/connector/kafka/connect/source/SolMessageProcessorIFTest.java
+++ b/src/test/java/com/solace/connector/kafka/connect/source/SolMessageProcessorIFTest.java
@@ -1,0 +1,142 @@
+package com.solace.connector.kafka.connect.source;
+
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_APPLICATION_MESSAGE_ID;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_APPLICATION_MESSAGE_TYPE;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_CORRELATION_ID;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_COS;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_DELIVERY_MODE;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_DESTINATION;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_REPLY_TO_DESTINATION;
+import static com.solace.connector.kafka.connect.source.SolaceSourceConstants.SOL_SH_REPLY_TO_DESTINATION_TYPE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.solace.connector.kafka.connect.source.msgprocessors.SolSampleSimpleMessageProcessor;
+import com.solacesystems.common.util.ByteArray;
+import com.solacesystems.jcsmp.BytesXMLMessage;
+import com.solacesystems.jcsmp.DeliveryMode;
+import com.solacesystems.jcsmp.SDTException;
+import com.solacesystems.jcsmp.SDTMap;
+import com.solacesystems.jcsmp.TextMessage;
+import com.solacesystems.jcsmp.User_Cos;
+import com.solacesystems.jcsmp.impl.QueueImpl;
+import com.solacesystems.jcsmp.impl.RawSMFMessageImpl;
+import com.solacesystems.jcsmp.impl.TopicImpl;
+import com.solacesystems.jcsmp.impl.sdt.MapImpl;
+import com.solacesystems.jcsmp.impl.sdt.StreamImpl;
+import java.math.BigInteger;
+import java.util.UUID;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SolMessageProcessorIFTest {
+
+  private SolMessageProcessorIF messageProcessor;
+
+  @BeforeEach
+  void setUp() {
+    messageProcessor = new SolSampleSimpleMessageProcessor();
+  }
+
+  @Test
+  void testUserPropertiesMappingGivenNullUserPropertyMap() {
+    final BytesXMLMessage message = mock(TextMessage.class);
+    when(message.getProperties()).thenReturn(null);
+
+    ConnectHeaders kafkaHeaders = messageProcessor.userPropertiesToKafkaHeaders(message);
+    assertThat("getProperties() is null", kafkaHeaders.isEmpty());
+  }
+
+  @Test
+  void testUserPropertiesMappingGiveEmptyUserPropertyMap() {
+    final SDTMap solMsgUserProperties = new MapImpl();
+    final BytesXMLMessage message = mock(TextMessage.class);
+    when(message.getProperties()).thenReturn(solMsgUserProperties);
+
+    ConnectHeaders kafkaHeaders = messageProcessor.userPropertiesToKafkaHeaders(message);
+    assertThat("solMsgUserProperties is empty", kafkaHeaders.isEmpty());
+  }
+
+  @Test
+  void testUserPropertiesMappingForGivenUserPropertyMap() throws SDTException {
+    final SDTMap solMsgUserProperties = new MapImpl();
+    solMsgUserProperties.putObject("null-value-user-property", null);
+    solMsgUserProperties.putBoolean("boolean-user-property", true);
+    solMsgUserProperties.putCharacter("char-user-property", 'C');
+    solMsgUserProperties.putDouble("double-user-property", 123.4567);
+    solMsgUserProperties.putFloat("float-user-property", 000.1f);
+    solMsgUserProperties.putInteger("int-user-property", 1);
+    solMsgUserProperties.putLong("long-user-property", 10000L);
+    solMsgUserProperties.putShort("short-user-property", Short.valueOf("20"));
+    solMsgUserProperties.putString("string-user-property", "value1");
+    solMsgUserProperties.putObject("bigInteger-user-property", new BigInteger("123456"));
+    solMsgUserProperties.putByte("byte-user-property", "A".getBytes()[0]);
+    solMsgUserProperties.putBytes("bytes-user-property", "Hello".getBytes());
+    solMsgUserProperties.putByteArray("byteArray-user-property",
+        new ByteArray("Hello World".getBytes()));
+    solMsgUserProperties.putDestination("topic-user-property",
+        TopicImpl.createFastNoValidation("testTopic"));
+    solMsgUserProperties.putDestination("queue-user-property",
+        QueueImpl.createFastNoValidation("testQueue"));
+
+    final BytesXMLMessage message = mock(TextMessage.class);
+    when(message.getProperties()).thenReturn(solMsgUserProperties);
+
+    final ConnectHeaders kafkaHeaders = messageProcessor.userPropertiesToKafkaHeaders(message);
+    assertThat(kafkaHeaders.size(), equalTo(message.getProperties().size()));
+
+    kafkaHeaders.iterator().forEachRemaining(
+        header -> assertThat(header.key(), solMsgUserProperties.containsKey(header.key())));
+  }
+
+  @Test
+  void testUserPropertiesMappingWhenGivenPropertyOfUnsupportedTypes()
+      throws SDTException {
+    final SDTMap solMsgUserProperties = new MapImpl();
+    solMsgUserProperties.putMap("map-user-property", new MapImpl());
+    solMsgUserProperties.putStream("stream-user-property", new StreamImpl());
+    solMsgUserProperties.putMessage("raw-message-user-property",
+        new RawSMFMessageImpl(new ByteArray("hello".getBytes())));
+
+    final BytesXMLMessage message = mock(TextMessage.class);
+    when(message.getProperties()).thenReturn(solMsgUserProperties);
+
+    ConnectHeaders kafkaHeaders = messageProcessor.userPropertiesToKafkaHeaders(message);
+    assertThat(solMsgUserProperties.size(), equalTo(message.getProperties().size()));
+    assertThat(kafkaHeaders.size(), equalTo(0));
+  }
+
+  @Test
+  void testSolaceStandardPropertiesMappingGivenSolaceMessage() {
+    final BytesXMLMessage message = mock(TextMessage.class);
+    when(message.getApplicationMessageId()).thenReturn(UUID.randomUUID().toString());
+    when(message.getApplicationMessageType()).thenReturn("testMessageType");
+    when(message.getCorrelationId()).thenReturn(UUID.randomUUID().toString());
+    when(message.getCos()).thenReturn(User_Cos.USER_COS_1);
+    when(message.getDestination()).thenReturn(QueueImpl.createFastNoValidation("testQueue"));
+    when(message.getDeliveryMode()).thenReturn(DeliveryMode.PERSISTENT);
+    when(message.getReplyTo()).thenReturn(QueueImpl.createFastNoValidation("testQueue"));
+
+    ConnectHeaders kafkaHeaders = messageProcessor.solacePropertiesToKafkaHeaders(message);
+    assertThat("kafkaHeaders should not be empty", !kafkaHeaders.isEmpty());
+    assertThat(message.getApplicationMessageId(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_APPLICATION_MESSAGE_ID).value()));
+    assertThat(message.getApplicationMessageType(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_APPLICATION_MESSAGE_TYPE).value()));
+    assertThat(message.getCorrelationId(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_CORRELATION_ID).value()));
+    assertThat(message.getCos().value(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_COS).value()));
+    assertThat(message.getDestination().getName(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_DESTINATION).value()));
+    assertThat(message.getDeliveryMode().name(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_DELIVERY_MODE).value()));
+
+    assertThat(message.getReplyTo().getName(),
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_REPLY_TO_DESTINATION).value()));
+    assertThat("queue",
+        equalTo(kafkaHeaders.lastWithName(SOL_SH_REPLY_TO_DESTINATION_TYPE).value()));
+  }
+}


### PR DESCRIPTION
DATAGO-67107 Added support for mapping/forwarding Solace message user properties to Kafka record headers
- Added two new configuration parameters: sol.message_processor.map_user_properties and sol.message_processor.map_solace_standard_properties
- Updated two Solace message processors
- Updated tests, sample configuration and docs